### PR TITLE
Added support for Client Narrative Actions

### DIFF
--- a/Runtime/Scripts/InworldCharacter.cs
+++ b/Runtime/Scripts/InworldCharacter.cs
@@ -105,6 +105,16 @@ namespace Inworld
             // 2. Send Text.
             InworldController.Instance.SendText(ID, text);
         }
+
+        /// <summary>
+        /// Send a narrative action to this character.
+        /// </summary>
+        /// <param name="narrative">the narrative text to send</param>
+        public virtual void SendNarrative(string narrative)
+        {
+            InworldController.Instance.SendNarrativeAction(ID, narrative);
+        }
+
         /// <summary>
         /// Default Version of sending triggers that can be used in UnityEvent registration.
         /// Parameters and values not supported.

--- a/Runtime/Scripts/InworldClient.cs
+++ b/Runtime/Scripts/InworldClient.cs
@@ -150,6 +150,12 @@ namespace Inworld
         /// <param name="textToSend">the message to send.</param>
         public virtual void SendText(string characterID, string textToSend) => Error = k_NotImplented;
         /// <summary>
+        /// Send a narrative action to an InworldCharacter in this current scene.
+        /// </summary>
+        /// <param name="characterID">the live session ID of the character to send</param>
+        /// <param name="narrativeAction">the narrative action to send.</param>
+        public virtual void SendNarrativeAction(string characterID, string narrativeAction) => Error = k_NotImplented;
+        /// <summary>
         /// Send the CancelResponse Event to InworldServer to interrupt the character's speaking.
         /// </summary>
         /// <param name="characterID">the live session ID of the character to send</param>

--- a/Runtime/Scripts/InworldController.cs
+++ b/Runtime/Scripts/InworldController.cs
@@ -163,6 +163,17 @@ namespace Inworld
             m_Client.SendText(charID, text);
         }
         /// <summary>
+        /// Send a narrative action to an InworldCharacter in this current scene.
+        /// </summary>
+        /// <param name="charID">the live session ID of the character to send</param>
+        /// <param name="narrativeAction">the narrative action to send.</param>
+        public void SendNarrativeAction(string charID, string narrativeAction)
+        {
+            if (Client.Status != InworldConnectionStatus.Connected)
+                InworldAI.LogException($"Tried to send narrative action to {charID}, but not connected to server.");
+            m_Client.SendNarrativeAction(charID, narrativeAction);
+        }
+        /// <summary>
         /// Send the CancelResponse Event to InworldServer to interrupt the character's speaking.
         /// </summary>
         /// <param name="charID">the live session ID of the character to send</param>

--- a/Runtime/Scripts/InworldWebSocketClient.cs
+++ b/Runtime/Scripts/InworldWebSocketClient.cs
@@ -58,7 +58,8 @@ namespace Inworld
                     narratedAction = new NarrativeAction
                     {
                         content = narrativeAction
-                    }
+                    }, 
+                    playback = "UTTERANCE"
                 }
             };
             string jsonToSend = JsonUtility.ToJson(packet);

--- a/Runtime/Scripts/InworldWebSocketClient.cs
+++ b/Runtime/Scripts/InworldWebSocketClient.cs
@@ -63,7 +63,6 @@ namespace Inworld
             };
             string jsonToSend = JsonUtility.ToJson(packet);
             Dispatch(packet);
-            Debug.Log("Send Narrative Action: " + jsonToSend);
             m_Socket.SendAsync(jsonToSend);
         }
         public override void SendCancelEvent(string characterID, string interactionID)

--- a/Runtime/Scripts/InworldWebSocketClient.cs
+++ b/Runtime/Scripts/InworldWebSocketClient.cs
@@ -43,6 +43,29 @@ namespace Inworld
             Dispatch(packet);
             m_Socket.SendAsync(jsonToSend);
         }
+        public override void SendNarrativeAction(string characterID, string narrativeAction)
+        {
+            if (string.IsNullOrEmpty(characterID) || string.IsNullOrEmpty(narrativeAction))
+                return;
+            InworldPacket packet = new ActionPacket
+            {
+                timestamp = InworldDateTime.UtcNow,
+                type = "ACTION",
+                packetId = new PacketId(),
+                routing = new Routing(characterID),
+                action = new ActionEvent
+                {
+                    narratedAction = new NarrativeAction
+                    {
+                        content = narrativeAction
+                    }
+                }
+            };
+            string jsonToSend = JsonUtility.ToJson(packet);
+            Dispatch(packet);
+            Debug.Log("Send Narrative Action: " + jsonToSend);
+            m_Socket.SendAsync(jsonToSend);
+        }
         public override void SendCancelEvent(string characterID, string interactionID)
         {
             if (string.IsNullOrEmpty(characterID))

--- a/Runtime/Scripts/PlayerControl/PlayerController.cs
+++ b/Runtime/Scripts/PlayerControl/PlayerController.cs
@@ -40,8 +40,11 @@ namespace Inworld.Sample
                 return;
             try
             {
-                if (InworldController.CurrentCharacter)
-                    InworldController.CurrentCharacter.SendText(m_InputField.text);
+                string text = m_InputField.text;
+                if (text.StartsWith("*"))
+                    InworldController.CurrentCharacter.SendNarrative(text.Remove(0, 1));
+                else
+                    InworldController.CurrentCharacter.SendText(text);
                 m_InputField.text = "";
             }
             catch (InworldException e)

--- a/Runtime/Scripts/Sample/ChatPanel.cs
+++ b/Runtime/Scripts/Sample/ChatPanel.cs
@@ -142,14 +142,29 @@ namespace Inworld.Sample
         {
             if (!m_ChatOptions.narrativeAction || actionPacket.action == null || actionPacket.action.narratedAction == null || string.IsNullOrWhiteSpace(actionPacket.action.narratedAction.content) || !IsUIReady)
                 return;
-            InworldCharacterData charData = InworldController.CharacterHandler.GetCharacterDataByID(actionPacket.routing.source.name);
-            if (charData == null)
-                return;
-            string key = m_ChatOptions.longBubbleMode ? actionPacket.packetId.interactionId : actionPacket.packetId.utteranceId;
-            string charName = charData.givenName ?? "Character";
-            Texture2D thumbnail = charData.thumbnail ? charData.thumbnail : InworldAI.DefaultThumbnail;
-            string content = $"<i><color=#AAAAAA>{actionPacket.action.narratedAction.content}</color></i>";
-            InsertBubble(key, m_BubbleLeft, charName, m_ChatOptions.longBubbleMode, content, thumbnail);
+            
+            switch (actionPacket.routing.source.type.ToUpper())
+            {
+                case "AGENT":
+                    InworldCharacterData charData = InworldController.CharacterHandler.GetCharacterDataByID(actionPacket.routing.source.name);
+                    if (charData == null)
+                        return;
+                    string key = m_ChatOptions.longBubbleMode ? actionPacket.packetId.interactionId : actionPacket.packetId.utteranceId;
+                    string charName = charData.givenName ?? "Character";
+                    Texture2D thumbnail = charData.thumbnail ? charData.thumbnail : InworldAI.DefaultThumbnail;
+                    string content = $"<i><color=#AAAAAA>{actionPacket.action.narratedAction.content}</color></i>";
+                    InsertBubble(key, m_BubbleLeft, charName, m_ChatOptions.longBubbleMode, content, thumbnail);
+                    break;
+                case "PLAYER":
+                    // YAN: Player Input does not apply longBubbleMode.
+                    //      And Key is always utteranceID.
+                    key = actionPacket.packetId.utteranceId;
+                    content = $"<i><color=#AAAAAA>{actionPacket.action.narratedAction.content}</color></i>";
+                    InsertBubble(key, m_BubbleRight, InworldAI.User.Name, false, content, InworldAI.DefaultThumbnail);
+                    break;
+            }
+            
+
         }
     }
 }


### PR DESCRIPTION
Narrative Actions can be sent from any chat panel that utilizes the ```Send Text``` method of PlayerController.cs by starting the input with a ```*```.