### PR TITLE
Fixed issues with interaction system

### DIFF
--- a/Runtime/Scripts/Interaction/Interaction.cs
+++ b/Runtime/Scripts/Interaction/Interaction.cs
@@ -15,6 +15,7 @@ namespace Inworld.Interactions
     {
         public string ID { get; set; }
         public DateTime RecentTime { get; set; }
+        public bool ReceivedInteractionEnd { get; set; }
         internal Utterance CurrentUtterance { get; set; }
         public bool IsEmpty => (m_Prepared == null || m_Prepared.IsEmpty) && (CurrentUtterance == null || CurrentUtterance.IsEmpty);
         
@@ -41,6 +42,8 @@ namespace Inworld.Interactions
         /// <returns>If it needs to dispatch immediately, will return, otherwise return null.</returns>
         public void Add(InworldPacket packet)
         {
+            if (packet is ControlPacket { Action: ControlType.INTERACTION_END })
+                ReceivedInteractionEnd = true;
             if (m_Processed.IsOverDue(packet) || m_Processed.Contains(packet))
             {
                 m_Processed.Add(packet);

--- a/Runtime/Scripts/Interaction/InworldAudioInteraction.cs
+++ b/Runtime/Scripts/Interaction/InworldAudioInteraction.cs
@@ -16,7 +16,9 @@ namespace Inworld.Interactions
         [Range (0, 1)][SerializeField] protected float m_VolumeOnPlayerSpeaking = 1f;
         AudioSource m_PlaybackSource;
         AudioClip m_AudioClip;
+        float m_WaitTimer;
         const string k_NoAudioCapabilities = "Audio Capabilities have been disabled in the Inworld AI object. Audio is required to be enabled when using the InworldAudioInteraction component.";
+        const float k_WaitTime = 2f;
         public override float AnimFactor
         {
             get => m_AnimFactor;
@@ -65,17 +67,28 @@ namespace Inworld.Interactions
                 yield return AdjustVolume();
                 yield return RemoveExceedItems();
                 yield return HandleNextUtterance();
+                yield return null;
             }
         }
         protected override IEnumerator PlayNextUtterance()
         {
+            if (!m_CurrentInteraction.CurrentUtterance.IsPlayable())
+            {
+                m_Character.OnInteractionChanged(m_CurrentInteraction.CurrentUtterance.Packets);
+                m_CurrentInteraction.CurrentUtterance = null;
+                m_WaitTimer = 0;
+                yield break;
+            }
+            if (!m_CurrentInteraction.CurrentUtterance.ContainsTextAndAudio() && !m_CurrentInteraction.ReceivedInteractionEnd && m_WaitTimer < k_WaitTime)
+            {
+                m_WaitTimer += Time.unscaledDeltaTime;
+                yield break;
+            }
             m_AudioClip = m_CurrentInteraction.CurrentUtterance.GetAudioClip();
             if (m_AudioClip == null)
             {
                 m_Character.OnInteractionChanged(m_CurrentInteraction.CurrentUtterance.Packets);
                 yield return new WaitForSeconds(m_CurrentInteraction.CurrentUtterance.GetTextSpeed() * m_TextSpeedMultipler);
-                if (m_CurrentInteraction != null)
-                    m_CurrentInteraction.CurrentUtterance = null;
             }
             else
             {
@@ -84,9 +97,10 @@ namespace Inworld.Interactions
                 m_PlaybackSource.PlayOneShot(m_AudioClip);
                 m_Character.OnInteractionChanged(m_CurrentInteraction.CurrentUtterance.Packets);
                 yield return new WaitUntil(() => !m_PlaybackSource.isPlaying);
-                if (m_CurrentInteraction != null)
-                    m_CurrentInteraction.CurrentUtterance = null;
             }
+            if(m_CurrentInteraction != null)
+                m_CurrentInteraction.CurrentUtterance = null;
+            m_WaitTimer = 0;
         }
         protected override void SkipCurrentUtterance()
         {

--- a/Runtime/Scripts/Interaction/InworldInteraction.cs
+++ b/Runtime/Scripts/Interaction/InworldInteraction.cs
@@ -134,6 +134,7 @@ namespace Inworld.Interactions
             {
                 yield return RemoveExceedItems();
                 yield return HandleNextUtterance();
+                yield return null;
             }
         }
         protected IEnumerator HandleNextUtterance()
@@ -151,7 +152,9 @@ namespace Inworld.Interactions
                 }
                 if (m_CurrentInteraction != null && m_CurrentInteraction.CurrentUtterance != null)
                 {
-                    if (InworldController.Audio.SampleMode != MicSampleMode.TURN_BASED || !InworldController.Audio.CurrentPlayingAudioSource || !InworldController.Audio.CurrentPlayingAudioSource.isPlaying)
+                    if (InworldController.Audio.SampleMode != MicSampleMode.TURN_BASED || 
+                               !InworldController.Audio.CurrentPlayingAudioSource || 
+                               !InworldController.Audio.CurrentPlayingAudioSource.isPlaying)
                         yield return PlayNextUtterance();
                 }
                 else if (m_Character)
@@ -160,7 +163,6 @@ namespace Inworld.Interactions
             else
             {
                 ShowContinue();
-                yield return null;
             }
         }
         void HideContinue()
@@ -178,7 +180,10 @@ namespace Inworld.Interactions
             if (!IsRelated(incomingPacket))
                 return;
             if (incomingPacket is CustomPacket || incomingPacket is EmotionPacket)
+            {
                 m_Character.ProcessPacket(incomingPacket);
+                return;
+            }
             if (incomingPacket.Source == SourceType.PLAYER && (incomingPacket.IsBroadCast || incomingPacket.IsTarget(m_Character.ID)))
             {
                 if (!(incomingPacket is AudioPacket))

--- a/Runtime/Scripts/Interaction/Utterance.cs
+++ b/Runtime/Scripts/Interaction/Utterance.cs
@@ -42,6 +42,32 @@ namespace Inworld.Interactions
             RecentTime = packetTime > RecentTime ? packetTime : RecentTime;
             m_Packets[packet.packetId.packetId] = packet;
         }
+        public bool IsPlayable()
+        {
+            foreach (InworldPacket p in m_Packets.Values)
+            {
+                if (p is TextPacket || p is AudioPacket)
+                    return true;
+            }
+            return false;
+        }
+        public bool ContainsTextAndAudio()
+        {
+            bool foundAudio = false, foundText = false;
+            foreach (InworldPacket p in m_Packets.Values)
+            {
+                switch (p)
+                {
+                    case TextPacket:
+                        foundText = true;
+                        break;
+                    case AudioPacket:
+                        foundAudio = true;
+                        break;
+                }
+            }
+            return foundAudio && foundText;
+        }
         public float GetTextSpeed()
         {
             foreach (InworldPacket p in m_Packets.Values)


### PR DESCRIPTION
InworldAudioInteraction:

- Added handling for non-text/audio utterances within `PlayNextUtterance`
- Text/Audio utterance now waits until both text and audio are received before playing
- If an utterance is missing either text or audio, then the system will wait until either:
  - The missing text/audio packet is received
  - Interaction End is received
  - It has been more than 2 seconds