### PR TITLE
AudioCapture Refactoring

### DIFF
--- a/Runtime/Scripts/AudioCapture.cs
+++ b/Runtime/Scripts/AudioCapture.cs
@@ -173,9 +173,15 @@ namespace Inworld
                     return;
                 m_IsCapturing = value;
                 if (m_IsCapturing)
+                {
+                    OnRecordingStart.Invoke();
                     StartAudio();
+                }
                 else
+                {
+                    OnRecordingEnd.Invoke();
                     StopAudio();
+                }
             }
         }
         /// <summary>

--- a/Runtime/Scripts/AudioCapture.cs
+++ b/Runtime/Scripts/AudioCapture.cs
@@ -6,9 +6,9 @@
  *************************************************************************************************/
 
 using Inworld.Entities;
-using Inworld.Packet;
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using UnityEngine;
 using UnityEngine.Events;
 using System.Collections.Generic;
@@ -49,13 +49,18 @@ namespace Inworld
         protected const int k_Channel = 1;
         protected AudioClip m_Recording;
         protected IEnumerator m_AudioCoroutine;
+        protected AudioChunk m_SendingAudioChunk;
+        protected bool m_DetectPlayerSpeaking = true;
+        protected bool m_IsRecording;
         protected bool m_IsPlayerSpeaking;
+        protected bool m_IsCapturing;
         protected float m_BackgroundNoise;
+        protected float m_CalibratingTime;
         // Last known position in AudioClip buffer.
         protected int m_LastPosition;
         // Size of audioclip used to collect information, need to be big enough to keep up with collect. 
         protected int m_BufferSize;
-        protected readonly List<string> m_AudioToPush = new List<string>();
+        protected readonly ConcurrentQueue<AudioChunk> m_AudioToPush = new ConcurrentQueue<AudioChunk>();
         protected List<AudioDevice> m_Devices = new List<AudioDevice>();
         protected byte[] m_ByteBuffer;
         protected float[] m_InputBuffer;
@@ -79,29 +84,6 @@ namespace Inworld
         {
             get => m_CharacterVolume;
             set => m_CharacterVolume = value;
-        }
-        /// <summary>
-        /// Signifies if audio is currently blocked from being captured.
-        /// </summary>
-        public bool IsBlocked { get; set; }
-        /// <summary>
-        /// Signifies if microphone is capturing audio.
-        /// </summary>
-        public bool IsCapturing
-        {
-            get => m_SamplingMode != MicSampleMode.NO_MIC;
-            set
-            {
-                if (value)
-                {
-                    if (m_SamplingMode == MicSampleMode.NO_MIC)
-                        m_SamplingMode = m_InitSampleMode;
-                }
-                else
-                {
-                    m_SamplingMode = MicSampleMode.NO_MIC;
-                }
-            }
         }
         /// <summary>
         /// Signifies if audio should be pushed to server automatically as it is captured.
@@ -144,14 +126,31 @@ namespace Inworld
         ///     (Either Enable AEC or it's Player's turn to speak)
         /// </summary>
         public bool IsAudioAvailable => m_SamplingMode == MicSampleMode.AEC || IsPlayerTurn;
-
+        /// <summary>
+        /// Toggle to enable auto push.
+        /// By default it will turn to false by PlayerController if any canvas was open.
+        /// </summary>
+        public bool DetectPlayerSpeaking
+        {
+            get => m_DetectPlayerSpeaking;
+            set => m_DetectPlayerSpeaking = value;
+        }
+        /// <summary>
+        /// By default, it's controlled by the Record UI button in PlayerController.
+        /// Note: This status is overwritten by Push to talk Hot key.
+        /// </summary>
+        public bool IsRecording
+        {
+            get => m_IsRecording || Input.GetKey(m_PushToTalkKey);
+            set => m_IsRecording = value;
+        }
         /// <summary>
         /// Signifies if user is speaking based on audio amplitude and threshold.
         /// </summary>
         public bool IsPlayerSpeaking
         {
             get => m_IsPlayerSpeaking;
-            set
+            protected set
             {
                 if (m_IsPlayerSpeaking == value)
                     return;
@@ -160,6 +159,27 @@ namespace Inworld
                     OnPlayerStartSpeaking?.Invoke();
                 else
                     OnPlayerStopSpeaking?.Invoke();
+            }
+        }
+        /// <summary>
+        /// Signifies it's currently capturing.
+        /// </summary>
+        public bool IsCapturing
+        {
+            get => m_IsCapturing;
+            set
+            {
+                if (m_IsCapturing == value)
+                    return;
+                m_IsCapturing = value;
+                if (m_IsCapturing)
+                {
+                    StartAudio();
+                }
+                else
+                {
+                    StopAudio();
+                }
             }
         }
         /// <summary>
@@ -235,31 +255,13 @@ namespace Inworld
             m_DeviceName = deviceName;
             StartMicrophone(m_DeviceName);
         }
-        /// <summary>
-        /// Unity's official microphone module starts recording, will trigger OnRecordingStart event.
-        /// </summary>
-        public void StartRecording()
+
+        public void PushAudioImmediate()
         {
-            if (IsCapturing)
+            if (!m_AudioToPush.TryDequeue(out AudioChunk audioChunk) || m_SendingAudioChunk == audioChunk)
                 return;
-#if UNITY_WEBGL && !UNITY_EDITOR
-            m_LastPosition = WebGLGetPosition();
-#else
-            m_LastPosition = Microphone.GetPosition(m_DeviceName);
-#endif
-            IsCapturing = true;
-            OnRecordingStart?.Invoke();
-        }
-        /// <summary>
-        /// Unity's official microphone module stops recording, will trigger OnRecordingEnd event.
-        /// </summary>
-        public void StopRecording()
-        {
-            if (!IsCapturing)
-                return;
-            m_AudioToPush.Clear();
-            IsCapturing = false;
-            OnRecordingEnd?.Invoke();
+            m_SendingAudioChunk = audioChunk;
+            SendAudio(audioChunk);
         }
         /// <summary>
         /// Manually push the audio wave data to server.
@@ -267,9 +269,9 @@ namespace Inworld
         public IEnumerator PushAudio()
         {
             yield return new WaitForSeconds(1);
-            foreach (string audioData in m_AudioToPush)
+            foreach (AudioChunk audioData in m_AudioToPush)
             {
-                InworldController.Instance.SendAudio(audioData);
+                SendAudio(audioData);
             }
             m_AudioToPush.Clear();
         }
@@ -290,12 +292,27 @@ namespace Inworld
             else
                 m_CurrentAudioSession.StartAudio(characters);
         }
+        public virtual void SendAudio(AudioChunk chunk)
+        {
+            if (InworldController.Client.Status != InworldConnectionStatus.Connected)
+                return;
 
+            if (chunk.targetName != InworldController.CurrentCharacter.BrainName)
+            {
+                List<string> list = new List<string> { chunk.targetName };
+                StartAudio(list);
+            }
+            InworldController.Client.SendAudioTo(chunk.chunk, InworldController.CharacterHandler.CurrentCharacterNames);
+        }
         /// <summary>
         ///     Recalculate the background noise (including bg music, etc)
         ///     Please call it whenever audio environment changed in your game.
         /// </summary>
-        public virtual void Calibrate() => m_BackgroundNoise = 0;
+        public virtual void Calibrate()
+        {
+            m_BackgroundNoise = 0;
+            m_CalibratingTime = 0;
+        }
         protected IEnumerator _Calibrate()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
@@ -305,11 +322,14 @@ namespace Inworld
             if (!Microphone.IsRecording(m_DeviceName))
                 StartMicrophone(m_DeviceName);
 #endif
-            while (m_BackgroundNoise == 0)
+            while (m_BackgroundNoise == 0 || m_CalibratingTime < m_BufferSeconds)
             {
                 int nSize = GetAudioData();
+                m_CalibratingTime += 0.1f;
                 yield return new WaitForSecondsRealtime(0.1f);
-                m_BackgroundNoise = CalculateAmplitude();
+                float amp = CalculateAmplitude();
+                if (amp > m_BackgroundNoise)
+                    m_BackgroundNoise = amp;
             }
         }
 #endregion
@@ -322,9 +342,6 @@ namespace Inworld
         
         protected virtual void OnEnable()
         {
-            InworldController.Client.OnPacketSent += OnPacketSent;
-            InworldController.CharacterHandler.OnCharacterListJoined += OnCharacterJoined;
-            InworldController.CharacterHandler.OnCharacterListLeft += OnCharacterLeft;
 #if UNITY_WEBGL && !UNITY_EDITOR
             StartWebMicrophone();
 #else            
@@ -334,14 +351,7 @@ namespace Inworld
         }
         protected virtual void OnDisable()
         {
-            if (InworldController.Instance)
-            {
-                InworldController.Client.OnPacketSent -= OnPacketSent;
-                InworldController.CharacterHandler.OnCharacterListJoined -= OnCharacterJoined;
-                InworldController.CharacterHandler.OnCharacterListLeft -= OnCharacterLeft;
-            }
             StopCoroutine(m_AudioCoroutine);
-            StopRecording();
             StopMicrophone(m_DeviceName);
         }
 
@@ -352,28 +362,18 @@ namespace Inworld
             WebGLDispose();
             s_WebGLBuffer = null;
 #endif
-            StopRecording();
             StopMicrophone(m_DeviceName);
         }
         protected void Update()
         {
-            HandlePTT();
             if (m_AudioToPush.Count > m_AudioToPushCapacity)
-                m_AudioToPush.RemoveAt(0);
+                m_AudioToPush.TryDequeue(out AudioChunk chunk);
         }
 
 #endregion
 
 #region Protected Functions
 
-        protected virtual void HandlePTT()
-        {
-            AutoPush = !Input.GetKey(m_PushToTalkKey);
-            if (Input.GetKeyDown(m_PushToTalkKey))
-                m_AudioToPush.Clear();
-            if (Input.GetKeyUp(m_PushToTalkKey))
-                StartCoroutine(PushAudio());
-        }
         protected virtual void Init()
         {
             m_CurrentAudioSession = new AudioSessionInfo();
@@ -386,46 +386,13 @@ namespace Inworld
             WebGLInit(OnWebGLInitialized);
 #endif
         }
-        protected virtual void OnPacketSent(InworldPacket packet)
-        {
-            if (packet is ControlPacket controlPacket)
-            {
-                switch (controlPacket.Action)
-                {
-                    case ControlType.AUDIO_SESSION_START:
-                        StartRecording();
-                        break;
-                    case ControlType.AUDIO_SESSION_END:
-                        StopRecording();
-                        break;
-                }
-            }
-        }
-        protected virtual void OnCharacterJoined(InworldCharacter character)
-        {
-            character.Event.onCharacterSelected.AddListener(OnCharacterSelected);
-            character.Event.onCharacterDeselected.AddListener(OnCharacterDeselected);
-        }
-        protected virtual void OnCharacterLeft(InworldCharacter character)
-        {
-            character.Event.onCharacterSelected.RemoveListener(OnCharacterSelected);
-            character.Event.onCharacterDeselected.RemoveListener(OnCharacterDeselected);
-        }
-        protected virtual void OnCharacterSelected(string brainName) => StartAudio();
-
-        protected virtual void OnCharacterDeselected(string brainName) => StopAudio();
-
         protected virtual IEnumerator AudioCoroutine()
         {
             while (true)
             {
                 yield return _Calibrate();
-                if (!IsCapturing || IsBlocked)
-                {
-                    yield return null;
-                    continue;
-                }
                 yield return Collect();
+                yield return OutputData();
             }
         }
         protected virtual IEnumerator Collect()
@@ -437,13 +404,26 @@ namespace Inworld
             int nSize = GetAudioData();
             if (nSize <= 0)
                 yield break;
+            bool isCharacterSpeaking = InworldController.CharacterHandler.IsAnyCharacterSpeaking;
             IsPlayerSpeaking = CalculateAmplitude() > m_BackgroundNoise * m_PlayerVolumeThreshold;
+            IsCapturing = IsRecording || DetectPlayerSpeaking && IsPlayerSpeaking;
+            string charName = InworldController.CharacterHandler.CurrentCharacter ? InworldController.CharacterHandler.CurrentCharacter.BrainName : "";
             byte[] output = Output(nSize * m_Recording.channels);
             string audioData = Convert.ToBase64String(output);
-            if (AutoPush)
-                InworldController.Instance.SendAudio(audioData);
-            else
-                m_AudioToPush.Add(audioData);
+            if (IsCapturing)
+                m_AudioToPush.Enqueue(new AudioChunk
+                {
+                    chunk = audioData,
+                    targetName = charName
+                });
+            yield return new WaitForSecondsRealtime(0.1f);
+        }
+        protected virtual IEnumerator OutputData()
+        {
+            if (InworldController.Client.Status == InworldConnectionStatus.Connected)
+                PushAudioImmediate();
+            if (m_AudioToPush.Count > m_AudioToPushCapacity)
+                m_AudioToPush.TryDequeue(out AudioChunk chunk);
             yield return new WaitForSecondsRealtime(0.1f);
         }
         protected int GetAudioData()

--- a/Runtime/Scripts/AudioCapture.cs
+++ b/Runtime/Scripts/AudioCapture.cs
@@ -35,6 +35,7 @@ namespace Inworld
         [SerializeField] protected int m_BufferSeconds = 1;
         [SerializeField] protected int m_AudioToPushCapacity = 100;
         [SerializeField] protected string m_DeviceName;
+        [SerializeField] protected bool m_DetectPlayerSpeaking = true;
         
         public UnityEvent OnRecordingStart;
         public UnityEvent OnRecordingEnd;
@@ -50,7 +51,6 @@ namespace Inworld
         protected AudioClip m_Recording;
         protected IEnumerator m_AudioCoroutine;
         protected AudioChunk m_SendingAudioChunk;
-        protected bool m_DetectPlayerSpeaking = true;
         protected bool m_IsRecording;
         protected bool m_IsPlayerSpeaking;
         protected bool m_IsCapturing;
@@ -366,6 +366,7 @@ namespace Inworld
         }
         protected void Update()
         {
+            HandleInput();
             if (m_AudioToPush.Count > m_AudioToPushCapacity)
                 m_AudioToPush.TryDequeue(out AudioChunk chunk);
         }
@@ -425,6 +426,10 @@ namespace Inworld
             if (m_AudioToPush.Count > m_AudioToPushCapacity)
                 m_AudioToPush.TryDequeue(out AudioChunk chunk);
             yield return new WaitForSecondsRealtime(0.1f);
+        }
+        protected virtual void HandleInput()
+        {
+            
         }
         protected int GetAudioData()
         {

--- a/Runtime/Scripts/AudioCapture.cs
+++ b/Runtime/Scripts/AudioCapture.cs
@@ -173,13 +173,9 @@ namespace Inworld
                     return;
                 m_IsCapturing = value;
                 if (m_IsCapturing)
-                {
                     StartAudio();
-                }
                 else
-                {
                     StopAudio();
-                }
             }
         }
         /// <summary>
@@ -366,7 +362,6 @@ namespace Inworld
         }
         protected void Update()
         {
-            HandleInput();
             if (m_AudioToPush.Count > m_AudioToPushCapacity)
                 m_AudioToPush.TryDequeue(out AudioChunk chunk);
         }
@@ -426,10 +421,6 @@ namespace Inworld
             if (m_AudioToPush.Count > m_AudioToPushCapacity)
                 m_AudioToPush.TryDequeue(out AudioChunk chunk);
             yield return new WaitForSecondsRealtime(0.1f);
-        }
-        protected virtual void HandleInput()
-        {
-            
         }
         protected int GetAudioData()
         {

--- a/Runtime/Scripts/CharacterHandler.cs
+++ b/Runtime/Scripts/CharacterHandler.cs
@@ -97,21 +97,7 @@ namespace Inworld
         /// <param name="givenName"></param>
         /// <returns></returns>
         public virtual InworldCharacter GetCharacterByGivenName(string givenName) => CurrentCharacters.FirstOrDefault(c => c.Name == givenName);
-        IEnumerator UpdateThumbnail(InworldCharacterData agent)
-        {
-            if (agent.thumbnail)
-                yield break;
-            string url = agent.characterAssets?.ThumbnailURL;
-            if (string.IsNullOrEmpty(url))
-                yield break;
-            UnityWebRequest uwr = new UnityWebRequest(url);
-            uwr.downloadHandler = new DownloadHandlerTexture();
-            yield return uwr.SendWebRequest();
-            if (uwr.isDone && uwr.result == UnityWebRequest.Result.Success)
-            {
-                agent.thumbnail = (uwr.downloadHandler as DownloadHandlerTexture)?.texture;
-            }
-        }
+
         /// <summary>
         /// Add a character to the character list.
         /// Triggers OnCharacterListJoined

--- a/Runtime/Scripts/Data/Entities/AudioDevice.cs
+++ b/Runtime/Scripts/Data/Entities/AudioDevice.cs
@@ -7,13 +7,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
 using UnityEngine.Scripting;
 
 
 namespace Inworld.Entities
 {
+    [Serializable]
+    public class AudioChunk
+    {
+        public string targetName; //YAN: character's full name or conversation's conversation ID.
+        public string chunk;
+    }
     [Serializable]
     public class AudioSessionInfo
     {
@@ -42,20 +46,9 @@ namespace Inworld.Entities
         {
             if (characterBrainNames.Count == 0)
                 return;
-            if (CharactersAreSame(characterBrainNames))
-                return;
             StopAudio();
             InworldController.Client.StartAudioTo(characterBrainNames);
             currentBrainNames = characterBrainNames;
-        }
-        /// <summary>
-        /// Check if the incoming characters are same in the current session.
-        /// </summary>
-        /// <param name="characterBrainNames">The brain names of the characters to enable audio interaction</param>
-        /// <returns></returns>
-        public bool CharactersAreSame(List<string> characterBrainNames)
-        {
-            return currentBrainNames.Count == characterBrainNames.Count && currentBrainNames.All(characterBrainNames.Contains);
         }
     }
     [Serializable]

--- a/Runtime/Scripts/Data/Entities/AudioDevice.cs
+++ b/Runtime/Scripts/Data/Entities/AudioDevice.cs
@@ -5,6 +5,7 @@
  * that can be found in the LICENSE.md file or at https://www.inworld.ai/sdk-license
  *************************************************************************************************/
 
+using Inworld.Packet;
 using System;
 using System.Collections.Generic;
 using UnityEngine.Scripting;

--- a/Runtime/Scripts/Data/Entities/InworldCharacterData.cs
+++ b/Runtime/Scripts/Data/Entities/InworldCharacterData.cs
@@ -5,8 +5,10 @@
  * that can be found in the LICENSE.md file or at https://www.inworld.ai/sdk-license
  *************************************************************************************************/
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Networking;
 
 namespace Inworld.Entities
 {
@@ -25,6 +27,21 @@ namespace Inworld.Entities
             brainName = charRef.character;
             givenName = charRef.characterOverloads[0].defaultCharacterDescription.givenName;
             characterAssets = new CharacterAssets(charRef.characterOverloads[0].defaultCharacterAssets);
+        }
+        public IEnumerator UpdateThumbnail()
+        {
+            if (thumbnail)
+                yield break;
+            string url = characterAssets?.ThumbnailURL;
+            if (string.IsNullOrEmpty(url))
+                yield break;
+            UnityWebRequest uwr = new UnityWebRequest(url);
+            uwr.downloadHandler = new DownloadHandlerTexture();
+            yield return uwr.SendWebRequest();
+            if (uwr.isDone && uwr.result == UnityWebRequest.Result.Success)
+            {
+                thumbnail = (uwr.downloadHandler as DownloadHandlerTexture)?.texture;
+            }
         }
         public string CharacterFileName
         {

--- a/Runtime/Scripts/Data/Entities/InworldEnum.cs
+++ b/Runtime/Scripts/Data/Entities/InworldEnum.cs
@@ -79,6 +79,12 @@ namespace Inworld
         // The content contains repetition issue
         INTERACTION_DISLIKE_TYPE_REPETITION = 7
     }
+    public enum MicrophoneMode
+    {
+        UNSPECIFIED,
+        OPEN_MIC, // For auto push
+        EXPECT_AUDIO_END // For push to talk
+    }
     public enum ControlType
     {
         UNKNOWN,

--- a/Runtime/Scripts/Data/Entities/PreviousDialog.cs
+++ b/Runtime/Scripts/Data/Entities/PreviousDialog.cs
@@ -50,6 +50,13 @@ namespace Inworld.Entities
 #endregion
 
 #region New
+
+    [Serializable]
+    public class Actor
+    {
+        public SourceType type;
+        public string name;
+    }
     [Serializable]
     public class ContinuationInfo
     {
@@ -65,7 +72,7 @@ namespace Inworld.Entities
     [Serializable]
     public class HistoryItem
     {
-        public string actor;
+        public Actor actor;
         public string text;
     }
     [Serializable]

--- a/Runtime/Scripts/Data/Packets/ControlPacket.cs
+++ b/Runtime/Scripts/Data/Packets/ControlPacket.cs
@@ -10,10 +10,16 @@ using UnityEngine;
 namespace Inworld.Packet
 {
     [Serializable]
+    public class AudioSessionPayload
+    {
+        public string mode;
+    }
+    [Serializable]
     public class ControlEvent
     {
         public string action;
         public string description;
+        public AudioSessionPayload audioSessionStart;
     }
     [Serializable]
     public class ControlPacket : InworldPacket

--- a/Runtime/Scripts/InworldCharacter.cs
+++ b/Runtime/Scripts/InworldCharacter.cs
@@ -8,7 +8,6 @@ using Inworld.Interactions;
 using Inworld.Packet;
 using Inworld.Entities;
 using Inworld.Sample;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -185,12 +184,15 @@ namespace Inworld
 
         protected virtual void OnEnable()
         {
+            InworldController.Audio.OnRecordingStart.AddListener(OnAudioCaptureStarted);
             InworldController.Client.OnStatusChanged += OnStatusChanged;
         }
+
         protected virtual void OnDisable()
         {
             if (!InworldController.Instance)
                 return;
+            InworldController.Audio.OnRecordingStart.RemoveListener(OnAudioCaptureStarted);
             InworldController.CharacterHandler.Unregister(this);
             InworldController.Client.OnStatusChanged -= OnStatusChanged;
         }
@@ -201,7 +203,10 @@ namespace Inworld
             InworldController.CharacterHandler.Unregister(this);
             m_CharacterEvents.onCharacterDestroyed?.Invoke(BrainName);
         }
-
+        protected virtual void OnAudioCaptureStarted()
+        {
+            CancelResponse();
+        }
         protected virtual void OnStatusChanged(InworldConnectionStatus newStatus)
         {
             if (newStatus == InworldConnectionStatus.Idle)

--- a/Runtime/Scripts/InworldClient.cs
+++ b/Runtime/Scripts/InworldClient.cs
@@ -856,6 +856,7 @@ namespace Inworld
             foreach (InworldCharacterData agent in loadSceneResponse.agents.Where(agent => !string.IsNullOrEmpty(agent.agentId) && !string.IsNullOrEmpty(agent.brainName)))
             {
                 m_LiveSessionData[agent.brainName] = agent;
+                StartCoroutine(agent.UpdateThumbnail());
             }
         }
         protected string _GetSessionFullName(string sceneFullName)

--- a/Runtime/Scripts/InworldClient.cs
+++ b/Runtime/Scripts/InworldClient.cs
@@ -955,10 +955,6 @@ namespace Inworld
             InworldNetworkPacket packetReceived = response.result;
             if (packetReceived.Type == PacketType.SESSION_RESPONSE)
             {
-                
-            }
-            if (packetReceived.Type == PacketType.SESSION_RESPONSE)
-            {
                 if (packetReceived.Packet is SessionResponsePacket sessionResponse)
                 {
                     m_CurrentSceneData = new LoadSceneResponse();

--- a/Runtime/Scripts/InworldClient.cs
+++ b/Runtime/Scripts/InworldClient.cs
@@ -11,11 +11,13 @@ using Inworld.Interactions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityWebSocket;
+using ErrorEventArgs = UnityWebSocket.ErrorEventArgs;
 
 namespace Inworld
 {
@@ -671,7 +673,11 @@ namespace Inworld
                 return;
             ControlEvent control = new ControlEvent
             {
-                action = ControlType.AUDIO_SESSION_START.ToString()
+                action = ControlType.AUDIO_SESSION_START.ToString(),
+                audioSessionStart = new AudioSessionPayload
+                {
+                    mode = MicrophoneMode.EXPECT_AUDIO_END.ToString()
+                }
             };
             OutgoingPacket rawData = new OutgoingPacket(control, characterToReceive);
             m_Prepared.Enqueue(rawData);
@@ -696,7 +702,11 @@ namespace Inworld
                 routing = new Routing(charID),
                 control = new ControlEvent
                 {
-                    action = ControlType.AUDIO_SESSION_START.ToString()
+                    action = ControlType.AUDIO_SESSION_START.ToString(),
+                    audioSessionStart = new AudioSessionPayload
+                    {
+                        mode = MicrophoneMode.EXPECT_AUDIO_END.ToString()
+                    }
                 }
             };
             string jsonToSend = JsonUtility.ToJson(packet);
@@ -715,7 +725,11 @@ namespace Inworld
                 return;
             ControlEvent control = new ControlEvent
             {
-                action = ControlType.AUDIO_SESSION_END.ToString()
+                action = ControlType.AUDIO_SESSION_END.ToString(),
+                audioSessionStart = new AudioSessionPayload()
+                {
+                    mode = MicrophoneMode.UNSPECIFIED.ToString()
+                }
             };
             OutgoingPacket output = new OutgoingPacket(control, characterToReceive);
             output.OnDequeue();
@@ -739,7 +753,11 @@ namespace Inworld
                 routing = new Routing(charID),
                 control = new ControlEvent
                 {
-                    action = ControlType.AUDIO_SESSION_END.ToString()
+                    action = ControlType.AUDIO_SESSION_END.ToString(),
+                    audioSessionStart = new AudioSessionPayload()
+                    {
+                        mode = MicrophoneMode.UNSPECIFIED.ToString()
+                    }
                 }
             };
             string jsonToSend = JsonUtility.ToJson(packet);
@@ -774,6 +792,7 @@ namespace Inworld
             if (!string.IsNullOrEmpty(output.RawPacket?.routing?.target?.name))
                 m_Socket.SendAsync(output.RawPacket.ToJson); // Do not enqueue dataChunk, They can be discarded.
         }
+
         /// <summary>
         /// Legacy Send the wav data to server to a specific character.
         /// Need to make sure that AUDIO_SESSION_START control event has been sent to server.

--- a/Runtime/Scripts/InworldClient.cs
+++ b/Runtime/Scripts/InworldClient.cs
@@ -633,9 +633,7 @@ namespace Inworld
         {
             if (string.IsNullOrEmpty(triggerName))
                 return;
-            Dictionary<string, string>  characterToReceive = GetCharacterDataByFullName(characters);
-            // if (characterToReceive.Count == 0)
-            //     return;
+            Dictionary<string, string> characterToReceive = GetCharacterDataByFullName(characters);
             m_Prepared.Enqueue(new OutgoingPacket(new CustomEvent(triggerName, parameters), characterToReceive));
         }
         /// <summary>
@@ -731,11 +729,9 @@ namespace Inworld
                     mode = MicrophoneMode.UNSPECIFIED.ToString()
                 }
             };
-            OutgoingPacket output = new OutgoingPacket(control, characterToReceive);
-            output.OnDequeue();
-            if (!string.IsNullOrEmpty(output.RawPacket?.routing?.target?.name))
-                m_Socket.SendAsync(output.RawPacket.ToJson); // Do not enqueue dataChunk, They can be discarded.
-            OnPacketSent?.Invoke(output.RawPacket);
+            OutgoingPacket rawData = new OutgoingPacket(control, characterToReceive);
+            m_Prepared.Enqueue(rawData);
+            OnPacketSent?.Invoke(rawData.RawPacket);
         }
         /// <summary>
         /// Legacy Send AUDIO_SESSION_END control events to server to.
@@ -744,7 +740,9 @@ namespace Inworld
         public virtual void StopAudio(string charID)
         {
             if (string.IsNullOrEmpty(charID))
+            {
                 return;
+            }
             InworldPacket packet = new ControlPacket
             {
                 timestamp = InworldDateTime.UtcNow,
@@ -754,7 +752,7 @@ namespace Inworld
                 control = new ControlEvent
                 {
                     action = ControlType.AUDIO_SESSION_END.ToString(),
-                    audioSessionStart = new AudioSessionPayload()
+                    audioSessionStart = new AudioSessionPayload
                     {
                         mode = MicrophoneMode.UNSPECIFIED.ToString()
                     }

--- a/Runtime/Scripts/PlayerControl/PlayerController3D.cs
+++ b/Runtime/Scripts/PlayerControl/PlayerController3D.cs
@@ -21,10 +21,9 @@ namespace Inworld.Sample
         [SerializeField] protected BubblePanel m_BubblePanel;
         
         /// <summary>
-        /// Get if any canvas is open.
+        /// Get if any canvas (except Status Canvas) is open.
         /// </summary>
         public override bool IsAnyCanvasOpen => m_ChatCanvas && m_ChatCanvas.activeSelf || 
-                                                m_StatusCanvas && m_StatusCanvas.activeSelf || 
                                                 m_FeedbackCanvas && m_FeedbackCanvas.activeSelf ||
                                                 m_OptionCanvas && m_OptionCanvas.activeSelf;
         
@@ -84,6 +83,7 @@ namespace Inworld.Sample
         {
             _HandleChatCanvas();
             _HandleOptionCanvas();
+            InworldController.Audio.DetectPlayerSpeaking = !IsAnyCanvasOpen;
         }
         protected void _HandleOptionCanvas()
         {
@@ -104,12 +104,10 @@ namespace Inworld.Sample
             {
                 m_PrevSelectingMethod = InworldController.CharacterHandler.SelectingMethod;
                 InworldController.CharacterHandler.SelectingMethod = CharSelectingMethod.Manual;
-                InworldController.Audio.IsCapturing = false;
             }
             else
             {
                 InworldController.CharacterHandler.SelectingMethod = m_PrevSelectingMethod;
-                InworldController.Audio.IsCapturing = true;
             }
             if (m_BubblePanel)
                 m_BubblePanel.UpdateContent();

--- a/Runtime/Scripts/PlayerControl/PlayerController3D.cs
+++ b/Runtime/Scripts/PlayerControl/PlayerController3D.cs
@@ -83,7 +83,7 @@ namespace Inworld.Sample
         {
             _HandleChatCanvas();
             _HandleOptionCanvas();
-            InworldController.Audio.DetectPlayerSpeaking = !IsAnyCanvasOpen;
+            InworldController.Audio.AutoDetectPlayerSpeaking = !IsAnyCanvasOpen;
         }
         protected void _HandleOptionCanvas()
         {

--- a/Runtime/Scripts/UI/BubblePanel.cs
+++ b/Runtime/Scripts/UI/BubblePanel.cs
@@ -67,7 +67,7 @@ namespace Inworld.UI
         }
         protected virtual void RemoveBubble(string key)
         {
-            if (!m_Bubbles.ContainsKey(key))
+            if (string.IsNullOrEmpty(key) || !m_Bubbles.ContainsKey(key))
                 return;
             InworldUIElement elementToDestroy = m_Bubbles[key];
             m_Bubbles.Remove(key);

--- a/Runtime/Scripts/UI/RecordButton.cs
+++ b/Runtime/Scripts/UI/RecordButton.cs
@@ -13,13 +13,11 @@ namespace Inworld.UI
     {
         public void OnPointerDown(PointerEventData eventData)
         {
-            InworldController.Audio.IsCapturing = true;
-            InworldController.Instance.StartAudio();
+            InworldController.Audio.IsRecording = true;
         }
         public void OnPointerUp(PointerEventData eventData)
         {
-            InworldController.Audio.IsCapturing = false;
-            InworldController.Instance.PushAudio();
+            InworldController.Audio.IsRecording = false;
         }
     }
 }

--- a/Tests/Runtime/InworldRuntimeTests.cs
+++ b/Tests/Runtime/InworldRuntimeTests.cs
@@ -129,7 +129,6 @@ namespace Inworld.Test
 			string agentID = InworldController.Client.LiveSessionData.Values.First().agentId;
 			InworldController.Client.StartAudio(agentID); ;
 			yield return new WaitForSeconds(0.1f);
-			InworldController.Audio.IsPlayerSpeaking = true;
 			InworldController.Client.SendAudio(agentID, k_AudioChunk);
 			yield return new WaitForSeconds(0.1f);
 			InworldController.Client.StopAudio(agentID);


### PR DESCRIPTION
For future server support and future voice recognition extension.

Now AUTO PUSH is removed. 

The auto push logic is merged into Push to talk, by calibrating and detecting characters speaking microphone voice.

So all the audio sending to server logic will be `AudioSessionStart` > `(immediately) AudioChunks` > ` (immediately) AudioSessionEnd`

As to say, the Push to talk logic will ALWAYS overwrite the auto player voice recognition.

The key property is `IsCapturing`, by setting it, it'll trigger Stop/Start Audio and cache the audio at the same time. It's calculated by lots of the factors, please do not manually set it unless necessary.

Sending Audio will be act the same as Sending Text, that we'll try to connect to server only when the first audio clip in the microphone is generated. 

(This is before multi agent v2, so CurrentCharacter is still valid. In the next version, I'll also add logic to discard invalid audio chunks)

NOTE: Currently in the prod, if you hold the push to talk, the character will interrupt you if you finished talking. It will not be the case in Dev as they've implemented Push to talk field for Audio session start.
