### PR TITLE
slack notification for regression tests

### DIFF
--- a/.github/workflows/RegressionTest.yml
+++ b/.github/workflows/RegressionTest.yml
@@ -1,7 +1,9 @@
 name: RegressionTests
 
 on:
-  workflow_dispatch:  # Allows manual triggering
+  workflow_dispatch:
+  repository_dispatch:
+    types: [dispatch-event]
 
 jobs:
   fetch-release:
@@ -9,7 +11,6 @@ jobs:
     outputs:
       releases: ${{ steps.fetch-releases.outputs.releases }}  
     steps:     
-      # Step 1: Fetch Inworld Unity Releases
       - name: Fetch Inworld Unity Releases
         id: fetch-releases
         run: |
@@ -17,31 +18,39 @@ jobs:
           echo "Found releases:"  
           echo $json                 
           echo "releases=$json" >> $GITHUB_OUTPUT     
-      
+
+  notify-start:
+    runs-on: ubuntu-latest
+    needs: fetch-release
+    steps:
+      - name: Send Start Notification to Slack
+        id: notify-slack-start
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: "🚀 Regression Tests Started"
+          SLACK_MESSAGE: "The regression tests have started for all releases. Updates will follow in this thread."
+          SLACK_ICON: "https://avatars.githubusercontent.com/u/117676025?v=4"
+          SLACK_COLOR: "#36a64f"
+
   run-tests:
     runs-on: ubuntu-latest 
-    needs: fetch-release
+    needs: [fetch-release, notify-start]
     strategy:
       matrix:
         releaseName: ${{ fromJson(needs.fetch-release.outputs.releases) }}
 
     steps:     
-      - name: Print Release Names
-        run: |
-          echo "Release names: ${{ matrix.releaseName.tag_name }}"
-          echo "Release URL: ${{ matrix.releaseName.download_url }}"
-      
-      # Step 2: Loop through each release and download the .tgz file
       - name: Download and Extract Release Files
         id: download-releases
         run: |
           mkdir -p releases
           echo "Downloading ${{ matrix.releaseName.tag_name }} from ${{ matrix.releaseName.download_url }}"
           mkdir -p "releases/${{ matrix.releaseName.tag_name }}"
-          echo "Make Dictionary: releases/${{ matrix.releaseName.tag_name }} Completed!!"
           wget -qO- "${{ matrix.releaseName.download_url }}" | tar xvz -C "releases/${{ matrix.releaseName.tag_name }}/"
               
       - name: Run Tests
+        id: run_tests
         uses: game-ci/unity-test-runner@v4
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -52,6 +61,14 @@ jobs:
           projectPath: releases/${{ matrix.releaseName.tag_name }}/package
           testMode: playmode
           unityVersion: 2022.3.34f1
-            
-       
 
+      - name: Notify Slack for Each Test
+        if: always()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: ":${{ job.status == 'success' && 'white_check_mark' || 'x' }}: Test Result for `${{ matrix.releaseName.tag_name }}`"
+          SLACK_MESSAGE: Regression tests ${{ job.status == 'success' && 'passed' || 'failed' }}.
+          SLACK_THREAD_TS: "${{ needs.notify-slack-start.outputs.ts }}"
+          SLACK_ICON: "https://avatars.githubusercontent.com/u/117676025?v=4"
+          SLACK_COLOR: "${{ job.status == 'success' && '#36a64f' || '#ff0000' }}"


### PR DESCRIPTION
slack notifications will be received in notifications-regression-tests channel.
I will work on triggering from inworld-deploy repo next.