### PR TITLE
Trigger Regression Tests on release

### DIFF
--- a/.github/workflows/RegressionTest.yml
+++ b/.github/workflows/RegressionTest.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [dispatch-event]
+  release:
+    types: [published]
 
 jobs:
   fetch-release:


### PR DESCRIPTION
In addition to triggering the regression tests when prod and prod azure are deployed, let's also add the trigger when a new release is published in this repo.

re: https://inworldai.atlassian.net/browse/SRE-1677